### PR TITLE
feat(native): 支持按 artifactId 选择流媒体制品

### DIFF
--- a/zlmedia4j-native/src/main/java/org/jetlinks/zlmedia/runner/process/EmbeddedProcessMediaRuntime.java
+++ b/zlmedia4j-native/src/main/java/org/jetlinks/zlmedia/runner/process/EmbeddedProcessMediaRuntime.java
@@ -22,18 +22,32 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import java.io.*;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
+/**
+ * Runs the embedded ZLMedia process from an installed native archive.
+ *
+ * Legacy constructors retain filesystem-first resource lookup. The native-artifact constructor
+ * only selects classpath archives whose owning JAR declares the requested Maven artifactId.
+ */
 @Slf4j
 public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
     private static final Map<String, String> installed = new ConcurrentHashMap<>();
+    private static final String[] SUPPORTED_ARCHIVES = {".zip", ".tar.gz", ".tar"};
 
     public EmbeddedProcessMediaRuntime(String workdir) {
         this(workdir, new ZLMediaConfigs());
@@ -41,6 +55,19 @@ public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
 
     public EmbeddedProcessMediaRuntime(String workdir, ZLMediaConfigs configs) {
         super(install(workdir), configs);
+    }
+
+    /**
+     * Creates a runtime using the native archive contributed by the requested Maven artifact.
+     *
+     * @param workdir       installation directory and cache key
+     * @param configs       runtime configuration
+     * @param nativeArtifact exact Maven artifactId of the JAR that owns the native archive
+     */
+    public EmbeddedProcessMediaRuntime(String workdir,
+                                       ZLMediaConfigs configs,
+                                       String nativeArtifact) {
+        super(install(workdir, nativeArtifact), configs);
     }
 
     public EmbeddedProcessMediaRuntime(String workdir,
@@ -62,6 +89,177 @@ public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
                 workdir
             ));
 
+    }
+
+    static String install(String workdir, String nativeArtifact) {
+        String normalizedOs = PlatformDependent.normalizedOs();
+        String normalizedArch = PlatformDependent.normalizedArch();
+        String basePath = "zlmedia-native/" + normalizedOs + "/" + normalizedArch;
+        List<String> searchedPaths = createSearchedPaths(basePath);
+        assertNativeArtifact(nativeArtifact, normalizedOs, normalizedArch, searchedPaths);
+        return installed.computeIfAbsent(
+            workdir,
+            dir -> install0(
+                selectNativeResource(
+                    searchedPaths,
+                    nativeArtifact,
+                    normalizedOs,
+                    normalizedArch
+                ),
+                workdir
+            )
+        );
+    }
+
+    private static void assertNativeArtifact(String nativeArtifact,
+                                             String normalizedOs,
+                                             String normalizedArch,
+                                             List<String> searchedPaths) {
+        if (nativeArtifact == null || nativeArtifact.isBlank()) {
+            throw new IllegalArgumentException(
+                resourceSelectionError(
+                    "nativeArtifact must not be blank",
+                    nativeArtifact,
+                    normalizedOs,
+                    normalizedArch,
+                    searchedPaths,
+                    List.of()
+                )
+            );
+        }
+    }
+
+    private static List<String> createSearchedPaths(String basePath) {
+        List<String> searchedPaths = new ArrayList<>(SUPPORTED_ARCHIVES.length);
+        for (String suffix : SUPPORTED_ARCHIVES) {
+            searchedPaths.add(basePath + suffix);
+        }
+        return List.copyOf(searchedPaths);
+    }
+
+    private static NativeResource selectNativeResource(List<String> searchedPaths,
+                                                       String nativeArtifact,
+                                                       String normalizedOs,
+                                                       String normalizedArch) {
+        List<String> discoveredResources = new ArrayList<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            throw new IllegalStateException(
+                resourceSelectionError(
+                    "Context ClassLoader is not available",
+                    nativeArtifact,
+                    normalizedOs,
+                    normalizedArch,
+                    searchedPaths,
+                    discoveredResources
+                )
+            );
+        }
+
+        try {
+            for (int i = 0; i < SUPPORTED_ARCHIVES.length; i++) {
+                String suffix = SUPPORTED_ARCHIVES[i];
+                String resourcePath = searchedPaths.get(i);
+                Enumeration<URL> resources = classLoader.getResources(resourcePath);
+                List<URL> matches = new ArrayList<>();
+                while (resources.hasMoreElements()) {
+                    URL resource = resources.nextElement();
+                    discoveredResources.add(resource.toExternalForm());
+                    if (matchesArtifact(resource, nativeArtifact)) {
+                        matches.add(resource);
+                    }
+                }
+                if (matches.size() > 1) {
+                    throw new IllegalStateException(
+                        resourceSelectionError(
+                            "Multiple native resources matched suffix " + suffix,
+                            nativeArtifact,
+                            normalizedOs,
+                            normalizedArch,
+                            searchedPaths,
+                            discoveredResources
+                        )
+                    );
+                }
+                if (matches.size() == 1) {
+                    return new NativeResource(suffix, matches.get(0));
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                resourceSelectionError(
+                    "Failed to inspect native resources",
+                    nativeArtifact,
+                    normalizedOs,
+                    normalizedArch,
+                    searchedPaths,
+                    discoveredResources
+                ),
+                e
+            );
+        }
+
+        throw new IllegalStateException(
+            resourceSelectionError(
+                "No native resource matched",
+                nativeArtifact,
+                normalizedOs,
+                normalizedArch,
+                searchedPaths,
+                discoveredResources
+            )
+        );
+    }
+
+    private static boolean matchesArtifact(URL resource, String nativeArtifact) throws IOException {
+        URLConnection connection = resource.openConnection();
+        if (connection instanceof JarURLConnection jarConnection) {
+            jarConnection.setUseCaches(false);
+            try (JarFile jar = jarConnection.getJarFile()) {
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
+                    if (entry.isDirectory()
+                        || !entryName.startsWith("META-INF/maven/")
+                        || !entryName.endsWith("/pom.properties")) {
+                        continue;
+                    }
+                    Properties properties = new Properties();
+                    try (InputStream input = jar.getInputStream(entry)) {
+                        properties.load(input);
+                    }
+                    if (nativeArtifact.equals(properties.getProperty("artifactId"))) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        if ("file".equalsIgnoreCase(resource.getProtocol())) {
+            // The artifact-aware entry never reads exploded or relative filesystem resources.
+            return false;
+        }
+        throw new IOException(
+            "Unsupported classpath resource connection: " + resource.toExternalForm()
+        );
+    }
+
+    private static String resourceSelectionError(String reason,
+                                                 String nativeArtifact,
+                                                 String normalizedOs,
+                                                 String normalizedArch,
+                                                 List<String> searchedPaths,
+                                                 List<String> discoveredResources) {
+        String artifact = nativeArtifact == null
+            ? "<null>"
+            : nativeArtifact.isBlank() ? "<blank>" : nativeArtifact;
+        return reason
+            + ", nativeArtifact=" + artifact
+            + ", normalizedOs=" + normalizedOs
+            + ", normalizedArch=" + normalizedArch
+            + ", searchedPaths=" + searchedPaths
+            + ", discoveredResources=" + discoveredResources;
     }
 
 
@@ -137,10 +335,9 @@ public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
 
     @SneakyThrows
     private static String install0(String basePath, String workdir) {
-        String[] supports = {".zip", ".tar.gz", ".tar"};
         String suffix = null;
         InputStream stream = null;
-        for (String _suffix : supports) {
+        for (String _suffix : SUPPORTED_ARCHIVES) {
             String file = basePath + _suffix;
             Resource resource = new FileSystemResource(file);
             if (!resource.exists()) {
@@ -155,34 +352,45 @@ public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
         if (suffix == null) {
             throw new IllegalAccessException("Not found ZLMedia Runtime Lib" + workdir);
         }
+        return install0(suffix, stream, workdir);
+    }
 
-        log.debug("install ZLMediaKit to {}", workdir);
-        try {
-            String mediaServer = switch (suffix) {
-                case ".zip" -> installZip(stream, workdir);
-                case ".tar" -> installTar(stream, workdir);
-                case ".tar.gz" -> installTar(new GzipCompressorInputStream(stream), workdir);
-                default -> throw new IllegalStateException("Unexpected file: " + suffix);
-            };
+    @SneakyThrows
+    private static String install0(NativeResource resource, String workdir) {
+        return install0(resource.suffix(), resource.openStream(), workdir);
+    }
 
-            if (mediaServer == null) {
-                throw new IllegalAccessException("No process file 'MediaServer' found in:" + workdir);
+    @SneakyThrows
+    private static String install0(String suffix, InputStream stream, String workdir) {
+        try (InputStream inputStream = stream) {
+            log.debug("install ZLMediaKit to {}", workdir);
+            try {
+                String mediaServer = switch (suffix) {
+                    case ".zip" -> installZip(inputStream, workdir);
+                    case ".tar" -> installTar(inputStream, workdir);
+                    case ".tar.gz" -> installTar(new GzipCompressorInputStream(inputStream), workdir);
+                    default -> throw new IllegalStateException("Unexpected file: " + suffix);
+                };
+
+                if (mediaServer == null) {
+                    throw new IllegalAccessException("No process file 'MediaServer' found in:" + workdir);
+                }
+
+                //copy config.ini
+                ClassPathResource config = new ClassPathResource("zlmedia-native/config.ini");
+                try (InputStream input = config.getInputStream();
+                     OutputStream output = Files.newOutputStream(
+                         Paths.get(mediaServer).getParent().resolve("config.ini"),
+                         StandardOpenOption.CREATE,
+                         StandardOpenOption.TRUNCATE_EXISTING,
+                         StandardOpenOption.WRITE)) {
+                    StreamUtils.copy(input, output);
+                }
+                return mediaServer;
+            } catch (Throwable e) {
+                log.error("install ZLMediaKit error", e);
+                throw e;
             }
-
-            //copy config.ini
-            ClassPathResource config = new ClassPathResource("zlmedia-native/config.ini");
-            try (InputStream input = config.getInputStream();
-                 OutputStream output = Files.newOutputStream(
-                     Paths.get(mediaServer).getParent().resolve("config.ini"),
-                     StandardOpenOption.CREATE,
-                     StandardOpenOption.TRUNCATE_EXISTING,
-                     StandardOpenOption.WRITE)) {
-                StreamUtils.copy(input, output);
-            }
-            return mediaServer;
-        } catch (Throwable e) {
-            log.error("install ZLMediaKit error", e);
-            throw e;
         }
     }
 
@@ -250,6 +458,16 @@ public class EmbeddedProcessMediaRuntime extends ProcessZLMediaRuntime {
                 PosixFilePermission.GROUP_READ,
                 PosixFilePermission.OTHERS_READ));
         } catch (Throwable ignore) {
+        }
+    }
+
+    private record NativeResource(String suffix, URL url) {
+
+        private InputStream openStream() throws IOException {
+            URLConnection connection = url.openConnection();
+            // Avoid retaining the owning JAR after installation through the global URL cache.
+            connection.setUseCaches(false);
+            return connection.getInputStream();
         }
     }
 

--- a/zlmedia4j-native/src/test/java/org/jetlinks/zlmedia/runner/process/EmbeddedProcessMediaRuntimeResourceTest.java
+++ b/zlmedia4j-native/src/test/java/org/jetlinks/zlmedia/runner/process/EmbeddedProcessMediaRuntimeResourceTest.java
@@ -1,0 +1,241 @@
+package org.jetlinks.zlmedia.runner.process;
+
+import io.netty.util.internal.PlatformDependent;
+import org.jetlinks.zlmedia.restful.ZLMediaConfigs;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmbeddedProcessMediaRuntimeResourceTest {
+
+    private static final String BM_ARTIFACT = "zlmedia-native-bm";
+    private static final String CV_ARTIFACT = "zlmedia-native-cv";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void selectsCvNativeResourceByArtifactId() throws Throwable {
+        Path bmJar = createNativeJar("bm.jar", BM_ARTIFACT, "BM");
+        Path cvJar = createNativeJar("cv.jar", CV_ARTIFACT, "CV");
+        Path workdir = tempDir.resolve("cv-runtime");
+
+        withNativeJars(List.of(bmJar, cvJar), () -> {
+            new EmbeddedProcessMediaRuntime(workdir.toString(), new ZLMediaConfigs(), CV_ARTIFACT);
+            return null;
+        });
+
+        assertEquals("CV", Files.readString(workdir.resolve("MediaServer")));
+    }
+
+    @Test
+    void selectsBmNativeResourceByArtifactId() throws Throwable {
+        Path cvJar = createNativeJar("cv.jar", CV_ARTIFACT, "CV");
+        Path bmJar = createNativeJar("bm.jar", BM_ARTIFACT, "BM");
+        Path workdir = tempDir.resolve("bm-runtime");
+
+        withNativeJars(List.of(cvJar, bmJar), () -> {
+            new EmbeddedProcessMediaRuntime(workdir.toString(), new ZLMediaConfigs(), BM_ARTIFACT);
+            return null;
+        });
+
+        assertEquals("BM", Files.readString(workdir.resolve("MediaServer")));
+    }
+
+    @Test
+    void closesNativeResourceWhenTarGzDecompressionFails() throws Throwable {
+        Path jar = createNativeJar(
+            "invalid-tar-gz.jar",
+            CV_ARTIFACT,
+            ".tar.gz",
+            "invalid-gzip-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        withNativeJars(
+            List.of(jar),
+            () -> assertThrows(
+                IOException.class,
+                () -> new EmbeddedProcessMediaRuntime(
+                    tempDir.resolve("invalid-tar-gz-runtime").toString(),
+                    new ZLMediaConfigs(),
+                    CV_ARTIFACT
+                )
+            )
+        );
+
+        Files.delete(jar);
+    }
+
+    @Test
+    void rejectsMissingNativeArtifactWhenNoResourcesExist() throws Throwable {
+        String missingArtifact = "zlmedia-native-missing";
+
+        IllegalStateException error = withNoNativeResources(
+            () -> assertThrows(
+                IllegalStateException.class,
+                () -> new EmbeddedProcessMediaRuntime(
+                    tempDir.resolve("missing-runtime").toString(),
+                    new ZLMediaConfigs(),
+                    missingArtifact
+                )
+            )
+        );
+
+        assertSelectionContext(error, missingArtifact);
+    }
+
+    @Test
+    void rejectsDuplicateNativeArtifactForSameSuffix() throws Throwable {
+        Path firstJar = createNativeJar("duplicate-first.jar", CV_ARTIFACT, "FIRST");
+        Path secondJar = createNativeJar("duplicate-second.jar", CV_ARTIFACT, "SECOND");
+
+        IllegalStateException error = withNativeJars(
+            List.of(firstJar, secondJar),
+            () -> assertThrows(
+                IllegalStateException.class,
+                () -> new EmbeddedProcessMediaRuntime(
+                    tempDir.resolve("duplicate-runtime").toString(),
+                    new ZLMediaConfigs(),
+                    CV_ARTIFACT
+                )
+            )
+        );
+
+        assertAll(
+            () -> assertTrue(error.getMessage().contains(CV_ARTIFACT)),
+            () -> assertTrue(error.getMessage().contains(PlatformDependent.normalizedOs())),
+            () -> assertTrue(error.getMessage().contains(PlatformDependent.normalizedArch())),
+            () -> assertTrue(error.getMessage().contains(nativeResourcePath())),
+            () -> assertTrue(error.getMessage().contains(firstJar.getFileName().toString())),
+            () -> assertTrue(error.getMessage().contains(secondJar.getFileName().toString()))
+        );
+    }
+
+    @Test
+    void rejectsBlankNativeArtifactBeforeResourceLookup() {
+        IllegalArgumentException nullError = assertThrows(
+            IllegalArgumentException.class,
+            () -> new EmbeddedProcessMediaRuntime(
+                tempDir.resolve("null-artifact").toString(),
+                new ZLMediaConfigs(),
+                null
+            )
+        );
+        IllegalArgumentException blankError = assertThrows(
+            IllegalArgumentException.class,
+            () -> new EmbeddedProcessMediaRuntime(
+                tempDir.resolve("blank-artifact").toString(),
+                new ZLMediaConfigs(),
+                "  "
+            )
+        );
+
+        assertSelectionContext(nullError, "<null>");
+        assertSelectionContext(blankError, "<blank>");
+    }
+
+    private Path createNativeJar(String fileName, String artifactId, String marker) throws IOException {
+        return createNativeJar(fileName, artifactId, ".zip", createNativeZip(marker));
+    }
+
+    private Path createNativeJar(String fileName,
+                                 String artifactId,
+                                 String suffix,
+                                 byte[] archive) throws IOException {
+        Path jar = tempDir.resolve(fileName);
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+            writeJarEntry(output, nativeResourcePath() + suffix, archive);
+            writeJarEntry(
+                output,
+                "META-INF/maven/org.jetlinks/" + artifactId + "/pom.properties",
+                ("artifactId=" + artifactId + "\n").getBytes(StandardCharsets.UTF_8)
+            );
+        }
+        return jar;
+    }
+
+    private byte[] createNativeZip(String marker) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream output = new ZipOutputStream(bytes)) {
+            output.putNextEntry(new ZipEntry("MediaServer"));
+            output.write(marker.getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+        return bytes.toByteArray();
+    }
+
+    private void writeJarEntry(JarOutputStream output, String name, byte[] content) throws IOException {
+        output.putNextEntry(new JarEntry(name));
+        output.write(content);
+        output.closeEntry();
+    }
+
+    private String nativeResourcePath() {
+        return "zlmedia-native/"
+            + PlatformDependent.normalizedOs()
+            + "/"
+            + PlatformDependent.normalizedArch();
+    }
+
+    private void assertSelectionContext(Throwable error, String nativeArtifact) {
+        String message = error.getMessage();
+        assertAll(
+            () -> assertTrue(message.contains("nativeArtifact=" + nativeArtifact)),
+            () -> assertTrue(message.contains("normalizedOs=" + PlatformDependent.normalizedOs())),
+            () -> assertTrue(message.contains("normalizedArch=" + PlatformDependent.normalizedArch())),
+            () -> assertTrue(message.contains(nativeResourcePath() + ".zip")),
+            () -> assertTrue(message.contains(nativeResourcePath() + ".tar.gz")),
+            () -> assertTrue(message.contains(nativeResourcePath() + ".tar"))
+        );
+    }
+
+    private <T> T withNoNativeResources(ThrowingSupplier<T> action) throws Throwable {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[0], null)) {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return action.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    private <T> T withNativeJars(List<Path> jars, ThrowingSupplier<T> action) throws Throwable {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        URL[] urls = jars
+            .stream()
+            .map(this::toUrl)
+            .toArray(URL[]::new);
+        try (URLClassLoader classLoader = new URLClassLoader(urls, previous)) {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return action.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    private URL toUrl(Path path) {
+        try {
+            return path.toUri().toURL();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 目的

- 在多个 Native JAR 使用相同资源路径时，按配置的完整 Maven artifactId 精确选择解压来源
- 避免依赖 classpath 顺序或从 JAR 文件名猜测 artifactId、version、classifier

## 核心变动

- `EmbeddedProcessMediaRuntime` 增加接收 `nativeArtifact` 的构造入口
- 沿用原 os/arch 和 `.zip -> .tar.gz -> .tar` 顺序枚举同名 classpath 资源
- 从资源所属 JAR 的 `META-INF/maven/**/pom.properties` 读取并精确匹配 `artifactId`
- 空配置、无匹配、同格式多匹配和不支持的资源连接直接失败，不增加默认制品或回退
- 新入口忽略文件系统资源；原构造入口继续保持文件系统优先
- 统一关闭 Native JAR 与解压输入流，异常 `.tar.gz` 不保留文件句柄

## 设计与测试目标

- 设计稿：`jetlinks-ultimate/docs/流媒体多制品单包按配置解压开发设计.md`，已在本地确认，按要求不提交远程
- 用户确认：已确认使用现有 `pom.properties` 修正文档中的 JAR 文件名切分缺口，当前进入 Ready for review
- 测试目标：CV/BM 精确选择、空配置、无资源、重复资源和异常流释放均已覆盖
- 注释 / 公共契约：适用；公共类职责和新构造入口参数边界已补 Javadoc
- 数据权限：不适用；未涉及业务数据
- 数据库兼容与性能：不适用；未涉及数据库或 SQL
- 链路追踪：不适用；仅为 JVM 启动阶段本地 classpath 资源定位
- MBean 运维可观测性：不适用；未新增常驻状态、队列、缓存或后台任务

## 测试结果

- 命令：`mvn -s D:/Development-Tools/maven/apache-maven-3.9.10-bin/apache-maven-3.9.10/conf/settings.xml -Dmaven.repo.local=D:/maven-out/repository -pl zlmedia4j-native clean test -Djacoco.skip=true -DjacocoArgLine=-javaagent:org.jacoco.agent-0.8.13-runtime.jar -Dtest=EmbeddedProcessMediaRuntimeResourceTest`
- 报告命令：`mvn -pl zlmedia4j-native org.jacoco:jacoco-maven-plugin:0.8.13:report -Djacoco.dataFile=zlmedia4j-native/target/jacoco-0.8.13.exec`
- 新增/更新测试：`EmbeddedProcessMediaRuntimeResourceTest` 6 个用例
- 单元测试：6 passed, 0 failed, 0 errors, 0 skipped
- 集成验证：跨仓库 Edge package 后使用实际 Spring Boot nested ClassLoader 成功选择目标 JAR、解压 `MediaServer.exe` 并生成 `config.ini`
- 压力测试：不适用；启动时只枚举有限 classpath 资源
- 覆盖率：JaCoCo 0.8.13 changed-line line 85.29%（87/102），达到 line ≥80%；`EmbeddedProcessMediaRuntime` 整类 line 54.37%（112/206）

## 文档同步情况

- 已同步：本地 `jetlinks-ultimate/docs/固件按模块升级实现说明.md` 已记录确认后的资源识别方式
- 未同步：实现说明和设计稿按用户要求不提交远程
- 说明：README 长期总览未变化；测试证据保留在 PR 描述中

## 风险与说明

- 影响范围：带 `nativeArtifact` 的新 Embedded ZLMedia classpath 解压入口
- 注释 / 公共契约：公共类与新构造入口已补 Javadoc
- 链路追踪 / 可观测性：不新增 TraceHolder；错误包含 artifactId、os、arch、查找路径和已发现资源
- MBean / 运维可观测性：不新增 MBean
- 未覆盖场景：所有真实操作系统与全部 13 个 Native 制品的启动矩阵
- 已知限制：新入口只接受 JAR classpath 资源；配置错误或匹配不唯一时直接失败，不回退
